### PR TITLE
geck examples minor fixes

### DIFF
--- a/geck/examples/search-stc.ipynb
+++ b/geck/examples/search-stc.ipynb
@@ -2,19 +2,22 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# Examples\n",
     "\n",
     "Connects to IPFS and instantiate configured indices for searching\n",
     "It will take a time depending on your IPFS performance"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "from stc_geck.client import StcGeck\n",
@@ -23,48 +26,87 @@
     "    timeout=300,\n",
     ")\n",
     "await geck.start()"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "GECK encapsulates Python client to Summa. It can be either external stand-alone server or embed server, but details are hidden behind `SummaClient` interface."
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "GECK encapsulates Python client to Summa. It can be either external stand-alone server or embed server, but details are hidden behind `SummaClient` interface."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "summa_client = geck.get_summa_client()"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Match search returns top-5 documents which contain `additive manufacturing` in their title, abstract or content."
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "Match search returns top-5 documents which contain `additive manufacturing` in their title, abstract or content."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ID: {'dois': ['10.21203/rs.3.rs-212116/v1']}\n",
+      "DOI: ['10.21203/rs.3.rs-212116/v1']\n",
+      "Title: Research on Gradient Additive Remanufacturing of Ultra-large Hot Forging Die Based on Automatic Wire Arc Additive Manufacturing Technology\n",
+      "Abstract: <abstract><header>Abstract</header>\n",
+      "<p>In this paper, an automatic WAAM technology are proposed to realize the gradient additive remanufacturing of ultra-large hot forging dies. Firstly, a vertical additive manufacturing strategy and a normal additive manufacturing strategy are proposed to meet different additive manufacturing demands. Secondly, the basic principle of layering design of ultra-large hot forging dies is developed, and the wear resistance of Ni-based, Co-based and Fe-based alloys at room temperature and high temperature is analyzed. The Co-based alloy has the best high temperature wear resistance, which can be used on the surface of the hot forging die to strengthen the die. In order to control the forming quality of additive manufacturing, the relationship between welding parameters and weld shape was discussed, and the reverse system of welding process parameters was built. Finally, a typical aviation ultra-large hot forging die is selected as the research object. According to different stress and temperature distribution in different regions of the ultra-large hot forging die in service, materials with different properties are used in corresponding regions to improve the service life of the die, reduce the remanufacturing costs and improve the remanufacturing efficiency. The experimental results show that the service life of the hot forging die repaired by the automatic gradient function WAAM technology is significantly increased, the material is reduced by more than 50% and the production efficiency is increased by more than 50%.</p></abstract>\n",
+      "Links: [{'cid': 'bafyb4idhyrmmv3y35kioq4crkwq2qgev22cgj2vz5td5r2hixermzdgyiu', 'extension': 'pdf', 'filesize': 2641562, 'md5': 'ff5707679c428842ea48c8699963a8a0', 'type': 'primary'}]\n",
+      "-----\n",
+      "ID: {'dois': ['10.1007/978-1-4419-1120-9'], 'libgen_ids': [566869, 893984, 943187]}\n",
+      "DOI: ['10.1007/978-1-4419-1120-9']\n",
+      "Title: Additive Manufacturing Technologies: Rapid Prototyping to Direct Digital Manufacturing\n",
+      "Abstract: <abstract><p><i>Additive Manufacturing Technologies: Rapid Prototyping to Direct Digital Manufacturing</i> deals with various aspects of joining materials to form parts. Additive Manufacturing (AM) is an automated technique for direct conversion of 3D CAD data into physical objects using a variety of approaches. Manufacturers have been using these technologies in order to reduce development cycle times and get their products to the market quicker, more cost effectively, and with added value due to the incorporation of customizable features. Realizing the potential of AM applications, a large number of processes have been developed allowing the use of various materials ranging from plastics to metals for product development. Authors Ian Gibson, David W. Rosen and Brent Stucker explain these issues, as well as:</p><p><i>Additive Manufacturing Technologies: Rapid Prototyping to Direct Digital Manufacturing</i> is the perfect book for researchers, students, practicing engineers, entrepreneurs, and manufacturing industry professionals interested in additive manufacturing.</p></abstract>\n",
+      "Links: [{'cid': 'bafyb4ifhgoqz4c6kghc5a5cuxfqlfpzzags6xar2qzapyltrhxmmzdvufm', 'extension': 'pdf', 'filesize': 12724678, 'md5': '0b2611fa299b6bd0904038562114e585', 'type': 'primary'}, {'cid': 'bafykbzacebyfx6ph42e4olj72zo3b6lphrjmzb7mheu4k47ecoifcio7du5ko', 'extension': 'pdf', 'filesize': 8711375, 'md5': '1d2db3b19f9562f7df40ab3be20cc428'}, {'cid': 'bafykbzacec3iauge26ukvh5vzvr6lo42msecwzkfk65jxouemul5pzw5trv5m', 'extension': 'pdf', 'filesize': 10117238, 'md5': '2956c90d54ca4d51a678a1cf1c0b9bef'}, {'cid': 'bafykbzacecu6jlq657l5s2yvhmwsj3u6luxqwhjxohlva2yl5vivaoitco4se', 'extension': 'pdf', 'filesize': 7238254, 'md5': '427c59fddc6144a0b195bc63be6359d9'}]\n",
+      "-----\n",
+      "ID: {'dois': ['10.1115/imece2022-88917']}\n",
+      "DOI: ['10.1115/imece2022-88917']\n",
+      "Title: Thermo-Mechanical Behavior of Multi-Layer Deposition for Wire Arc Additive Manufacturing of Structural Steel: Wire Arc Additive Manufacturing\n",
+      "Abstract: Abstract\n",
+      "Wire arc additive manufacturing (WAAM) process, following the directed energy deposition (DED) technique, has evolved as one of the most prominent additive manufacturing (AM) technologies to fabricate large and intricate shapes of metallic components. The physical basis of the WAAM process is associated with rapid heating, melting, layer-by-layer melt deposition, solidification, and moderate cooling rate of the fabricated part. Consequently, different regions of the additive manufactured part experience variable heating and cooling cycles due to repeated heating and cooling. The continuously varying transient thermal cycles lead to residual stresses and distortion in fabricated components, mainly influenced by the temperature gradient along the build direction. The generation of residual stress and distortion result in warping, delamination, and unfavorable fatigue properties of the AM components. The in-situ prediction of transient temperature profile and its impact on residual stresses in an arc-based DED technique is practically impossible by any contact measurement technologies. As the cooling or idle times between the successively deposited layers play a significant role in the thermomechanical behavior of as-deposited materials, the inclination towards developing a numerical model by considering different process variants in the layer-by-layer deposition process is evolving. In the present work, a finite-element-based thermo-mechanical 3D model is developed for the WAAM process by triggering the effect of the inter-pass cooling period. The model results are validated with experiments reported in independent literature. Increasing the inter-layer dwell time decreases built material’s peak temperature and residual stress. At the same time, the distribution of effective stress along the built material’s center line increases with idle times.\n",
+      "Links: [{'cid': 'bafyb4idwmkdwjkiglv67oa7czaz7nqysqfedwg437r6iljxla7timyk5ae', 'extension': 'pdf', 'filesize': 3514640, 'md5': '88dd37e1b4345b0f2297774e29a16a8a', 'type': 'primary'}]\n",
+      "-----\n",
+      "ID: {'dois': ['10.1016/j.jmapro.2023.05.102']}\n",
+      "DOI: ['10.1016/j.jmapro.2023.05.102']\n",
+      "Title: A LCA and LCC analysis of pure subtractive manufacturing, wire arc additive manufacturing, and selective laser melting approaches\n",
+      "Abstract: <abstract>The development of sustainable manufacturing solutions is gaining attention in the manufacturing sector due to increased awareness about climate change and the formulation of stricter environmental legislation. Sustainable manufacturing involves the development of solutions that are environmentally friendly and cost-effective at the same time. Considering the opportunities and limitations of metal subtractive and additive manufacturing approaches from a sustainability perspective, this study aims to compare the environmental impact and production costs associated with the manufacture of a marine propeller using pure subtractive CNC milling along with additive Wire arc additive manufacturing (WAAM) and Selective Laser Melting (SLM) approaches. Life Cycle Assessment (LCA) and Life Cycle Costing (LCC) are used to quantify the environmental and economic impacts, respectively for each manufacturing approach. Based on the LCA and LCC models formulated, and the input data collected, the WAAM approach is observed to be the most environmentally and cost-efficient approach for the marine propeller analyzed. WAAM shows an environmental impact about 2.5 times and 3.4 times lower than pure CNC milling and SLM approaches, respectively mainly due to its better material and energy efficiencies. The effect of key variables on the environmental impact and production cost such as raw material, electricity, and post-processing parameters like a material allowance for finish machining and cutting velocity is also studied to suggest the parameters ensuring sustainable performance for a particular approach. WAAM is seen to be the most economical and ecological option for a post-processing material allowance under 4 mm and the finish machining velocities below 96 m/min. Additionally, an uncertainty assessment using the Monte Carlo analysis method is also performed to give a probabilistic range of environmental impacts and production costs considering the input data uncertainties for each approach. The methodology used in this study can be applied to other additive manufacturing processes. This study can be of potential help to AM practitioners in decision-making on selecting the most sustainable approach for manufacturing their products.</abstract>\n",
+      "Links: [{'cid': 'bafyb4idx5w4huvv4immrf4tmo2jcrlxgpnsulukvt5xkigs7ycbnwpdo2e', 'extension': 'pdf', 'filesize': 5350543, 'md5': 'b6dfb54c0742a4d8331b41377c1df76d', 'type': 'primary'}]\n",
+      "-----\n",
+      "ID: {'dois': ['10.1007/s12008-023-01243-6']}\n",
+      "DOI: ['10.1007/s12008-023-01243-6']\n",
+      "Title: Advanced solid-state welding based on computational manufacturing using the additive manufacturing process\n",
+      "Abstract: The world is undergoing a paradigm shift in how products are manufactured. The fourth industrial revolution, or Industry 4.0, is given greater importance by industries and companies worldwide as they bridge the gap between technology and manufacturing processes. Digital manufacturing has become a key research area as it can boost the productivity of all manufacturing processes by using advanced techniques such as machine learning, the Internet of Things, and artificial intelligence. These techniques have been used in tandem with numerous hybrid additive manufacturing processes to increase precision, create unlimited complex geometries, reduce material waste, change the constraints of the part during manufacturing if needed, and reduce the capital requirement. However, conventional welding techniques were harmful to humans, provided a poor surface finish, and proved difficult for welding complex parts. With hybrid additive manufacturing techniques combined with conventional welding techniques, conventional welding processes have been automated, reducing human intervention. This can be done using some of the latest technologies and concepts invented, such as robots, cobots, artificial intelligence, and virtual reality. Some of these new concepts and technologies, such as machine learning, virtual reality, and the Internet of Things, can optimize various welding parameters and improve remote welding technology. In addition, this paper thoroughly explores four important IT-based domains of digital manufacturing used in welding processes: robots, the Internet of Things, machine learning, and artificial intelligence. These concepts have influenced traditional welding processes by presenting the various parameters used to examine the impact. In addition, this paper also considers the potential scope of research. Also, this paper would look at different digital manufacturing processes and how they are used to make hybrid parts based on additive manufacturing.\n",
+      "Links: [{'cid': 'bafyb4ih4gel6ntcqxn5obmycz5hr4nwryqydppjt7rz7amtgd42qeiaf5y', 'extension': 'pdf', 'type': 'primary'}]\n",
+      "-----\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "\n",
-    "search_response = await summa_client.search([{\n",
+    "search_response = await summa_client.search({\n",
     "    \"index_alias\": \"nexus_science\",\n",
     "    \"query\": {\n",
     "        \"match\": {\n",
@@ -74,31 +116,32 @@
     "    },\n",
     "    \"collectors\": [{\"top_docs\": {\"limit\": 5}}],\n",
     "    \"is_fieldnorms_scoring_enabled\": False,\n",
-    "}])\n",
+    "})\n",
     "for scored_document in search_response.collector_outputs[0].documents.scored_documents:\n",
     "    document = json.loads(scored_document.document)\n",
     "    print('ID:', document['id'])\n",
+    "    print('DOI:', document['id']['dois'])\n",
     "    print('Title:', document['title'])\n",
     "    print('Abstract:', document.get('abstract'))\n",
     "    print('Links:', document.get('links'))\n",
     "    print('-----')"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Let's download PDFs. `links` field of the document contains IPFS hashes of files with articles. So firtly we check if the link is present and then download this file."
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "Let's download PDFs. `links` field of the document contains IPFS hashes of files with articles. So firtly we check if the link is present and then download this file."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "from urllib.parse import quote\n",
@@ -108,47 +151,77 @@
     "    if 'links' not in document:\n",
     "        continue\n",
     "    link = document['links'][0]\n",
-    "    with open(quote(document['id'], safe='') + '.' + link['extension'], 'wb') as f:\n",
+    "    with open(quote(document['id']['dois'][0], safe='') + '.' + link['extension'], 'wb') as f:\n",
     "        pdf_file = await geck.download(link['cid'])\n",
     "        f.write(pdf_file)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Below we have several more examples of search queries. More documentation on how to do queries to Summa can be found at https://izihawa.github.io/summa/core/query-dsl/"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "Below we have several more examples of search queries. More documentation on how to do queries to Summa can be found at https://izihawa.github.io/summa/core/query-dsl/"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Long COVID Diary - Design and Development of a Support Application for People with Long COVID\n",
+      "-----\n"
+     ]
+    }
+   ],
    "source": [
     "# Term search in science collection\n",
-    "await summa_client.search([{\n",
+    "search_response = await summa_client.search({\n",
     "    \"index_alias\": \"nexus_science\",\n",
     "    \"query\": {\"term\": {\"field\": \"id.dois\", \"value\": \"10.1109/healthcom54947.2022.9982758\"}},\n",
     "    \"collectors\": [{\"top_docs\": {\"limit\": 1}}],\n",
     "    \"is_fieldnorms_scoring_enabled\": False,\n",
-    "}])"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "})\n",
+    "for found_document in search_response.collector_outputs[0].documents.scored_documents:\n",
+    "    document = json.loads(found_document.document)\n",
+    "    print(document['title'])\n",
+    "    print('-----')"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fetal hemoglobin-containing cells have the same mean corpuscular hemoglobin as cells without fetal hemoglobin: a reciprocal relationship between gamma- and beta-globin gene expression in normal subjects and in those with high fetal hemoglobin production\n",
+      "-----\n",
+      "Fetal hemoglobin-containing cells have the same mean corpuscular hemoglobin as cells without fetal hemoglobin: a reciprocal relationship between gamma- and beta-globin gene expression in normal subjects and in those with high fetal hemoglobin production\n",
+      "-----\n",
+      "Fetal hemoglobin production in cultures of primitive and mature human erythroid progenitors: differentiation affects the quantity of fetal hemoglobin produced per fetal-hemoglobin-containing cell\n",
+      "-----\n",
+      "Fetal hemoglobin production in cultures of primitive and mature human erythroid progenitors: differentiation affects the quantity of fetal hemoglobin produced per fetal-hemoglobin-containing cell\n",
+      "-----\n",
+      "Fetal hemoglobin (HbF) synthesis in baboons, Papio cynocephalus. Analysis of fetal and adult hemoglobin synthesis during fetal development\n",
+      "-----\n"
+     ]
+    }
+   ],
    "source": [
     "# Complex query and count results too\n",
-    "await summa_client.search([{\n",
+    "search_response = await summa_client.search({\n",
     "    \"index_alias\": \"nexus_science\",\n",
     "    \"query\": {\"boolean\": {\"subqueries\": [{\n",
     "        \"occur\": \"should\",\n",
@@ -169,11 +242,12 @@
     "    }]}},\n",
     "    \"collectors\": [{\"top_docs\": {\"limit\": 5}}, {\"count\": {}}],\n",
     "    \"is_fieldnorms_scoring_enabled\": False,\n",
-    "}])"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "})\n",
+    "for found_document in search_response.collector_outputs[0].documents.scored_documents:\n",
+    "    document = json.loads(found_document.document)\n",
+    "    print(document['title'])\n",
+    "    print('-----')"
+   ]
   }
  ],
  "metadata": {
@@ -185,14 +259,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/geck/examples/search-stc.py
+++ b/geck/examples/search-stc.py
@@ -1,0 +1,61 @@
+import json
+import asyncio
+import argparse
+from stc_geck.client import StcGeck
+
+LIMIT = 5
+
+async def get_response(summa_client):
+
+
+    # Match search returns top-5 documents which contain `additive manufacturing` in their title, abstract or content.
+    search_response = await summa_client.search({
+        "index_alias": "nexus_science",
+        "query": {
+            "match": {
+                "value": "additive manufacturing",
+                "query_parser_config": {"default_fields": ["abstract", "title", "content"]}
+            }
+        },
+        "collectors": [{"top_docs": {"limit": LIMIT}}],
+        "is_fieldnorms_scoring_enabled": False,
+    })
+    return search_response
+
+async def main():
+    
+    geck = StcGeck(
+        ipfs_http_base_url='http://127.0.0.1:8080',
+        timeout=300,
+    )
+
+    # Connects to IPFS and instantiate configured indices for searching It will take a time depending on your IPFS performance
+    await geck.start()
+
+    # GECK encapsulates Python client to Summa. It can be either external stand-alone server or embed server, but details are hidden behind SummaClient interface.
+    summa_client = geck.get_summa_client()    
+    
+    search_response = await get_response(summa_client=summa_client)
+    
+    for scored_document in search_response.collector_outputs[0].documents.scored_documents:
+        
+        document = json.loads(scored_document.document)
+        
+        print('DOI:', document['id']['dois'][0])
+        print('Title:', document['title'])
+        print('Abstract:', document.get('abstract'))
+        print('Links:', document.get('links'))
+        print('-----')        
+    
+    await geck.stop()
+    
+if __name__ == "__main__":
+
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument('--limit', type=int, default=LIMIT)
+    args = argparser.parse_args()
+    
+    LIMIT = args.limit    
+    
+    asyncio.run(main())
+    


### PR DESCRIPTION
- on `geck/examples/search-stc.ipynb`, `summa_client.search` was receiving lists of dicts, but since it expects a single dict, that was leading to runtime error. I fixed that and I also tried to slightly improve the notebook (with prints for each usage example)
- I also added a script version of the code in the `README.md`